### PR TITLE
Fix typo in example from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const culqi = new Culqi({
         amount: '10000',
         currency_code: 'PEN',
         email: 'richard@piedpiper.com',
-        id: 'tkn_test_xxxxxxxxxxxxxxxx',
+        source_id: 'tkn_test_xxxxxxxxxxxxxxxx',
     });
 
     console.log(charge.id);


### PR DESCRIPTION
Just a small oversight in the example from the README where the property for passing the token for charge creation is incorrect from the actual property name.

Thanks for making this available, saved me a chunk of time at work :shipit:.